### PR TITLE
Replace ClamAV::Client with Net::ClamAV::Client to suport clamav-0.104.

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -7,7 +7,7 @@ generated_by:        ExtUtils::MakeMaker version 6.32
 distribution_type:   module
 requires:     
     Catalyst:                      0
-    ClamAV::Client:                0.1
+    Net:ClamAV::Client:            0
     Test::More:                    0
 meta-spec:
     url:     http://module-build.sourceforge.net/META-spec-v1.2.html

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,7 +12,7 @@ WriteMakefile(
     PREREQ_PM => {
         'Catalyst'       => 0,
         'Test::More'     => 0,
-        'ClamAV::Client' => 0.10,
+        'Net::ClamAV::Client' => 0,
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'Catalyst-Plugin-ClamAV-*' },

--- a/lib/Catalyst/Plugin/ClamAV.pm
+++ b/lib/Catalyst/Plugin/ClamAV.pm
@@ -18,9 +18,10 @@ sub clamscan {
     my $found = 0;
     my @virus;
     foreach my $name (@names) {
-        my $upload = $c->req->upload( $name );
-        next unless $upload;
+        my @uploads = $c->req->upload( $name );
+        next unless @uploads;
 
+        foreach my $upload (@uploads) {
         my $fh = $upload->fh;
         if ($fh) {
             my $virus = $scanner->scan_stream( $fh );
@@ -33,6 +34,7 @@ sub clamscan {
                 };
                 $c->log->warn( __PACKAGE__ . " VIRUS found. signature='$virus'" );
             }
+        }
         }
     }
     return wantarray ? @virus : $found;

--- a/lib/Catalyst/Plugin/ClamAV.pm
+++ b/lib/Catalyst/Plugin/ClamAV.pm
@@ -19,9 +19,10 @@ sub clamscan {
     my $found = 0;
     my @virus;
     foreach my $name (@names) {
-        my $upload = $c->req->upload( $name );
-        next unless $upload;
+        my @uploads = $c->req->upload( $name );
+        next unless @uploads;
 
+        foreach my $upload (@uploads) {
         my $fh = $upload->fh;
         if ($fh) {
             my $io = IO::Handle->new_from_fd($fh, 'r');
@@ -35,6 +36,7 @@ sub clamscan {
                 };
                 $c->log->warn( __PACKAGE__ . " VIRUS found. signature='$virus'" );
             }
+        }
         }
     }
     return wantarray ? @virus : $found;

--- a/lib/Catalyst/Plugin/ClamAV.pm
+++ b/lib/Catalyst/Plugin/ClamAV.pm
@@ -23,20 +23,20 @@ sub clamscan {
         next unless @uploads;
 
         foreach my $upload (@uploads) {
-        my $fh = $upload->fh;
-        if ($fh) {
-            my $io = IO::Handle->new_from_fd($fh, 'r');
-            my $virus = $scanner->scanStreamFH( $io );
-            seek( $fh, 0, 0 );
-            if ( $virus ) {
-                $found++;
-                push @virus, {
-                    name      => $name,
-                    signature => $virus,
-                };
-                $c->log->warn( __PACKAGE__ . " VIRUS found. signature='$virus'" );
+            my $fh = $upload->fh;
+            if ($fh) {
+                my $io = IO::Handle->new_from_fd($fh, 'r');
+                my $virus = $scanner->scanStreamFH( $io );
+                seek( $fh, 0, 0 );
+                if ( $virus ) {
+                    $found++;
+                    push @virus, {
+                        name      => $name,
+                        signature => $virus,
+                    };
+                    $c->log->warn( __PACKAGE__ . " VIRUS found. signature='$virus'" );
+                }
             }
-        }
         }
     }
     return wantarray ? @virus : $found;

--- a/lib/Catalyst/Plugin/ClamAV.pm
+++ b/lib/Catalyst/Plugin/ClamAV.pm
@@ -22,19 +22,19 @@ sub clamscan {
         next unless @uploads;
 
         foreach my $upload (@uploads) {
-        my $fh = $upload->fh;
-        if ($fh) {
-            my $virus = $scanner->scan_stream( $fh );
-            seek( $fh, 0, 0 );
-            if ( $virus ) {
-                $found++;
-                push @virus, {
-                    name      => $name,
-                    signature => $virus,
-                };
-                $c->log->warn( __PACKAGE__ . " VIRUS found. signature='$virus'" );
+            my $fh = $upload->fh;
+            if ($fh) {
+                my $virus = $scanner->scan_stream( $fh );
+                seek( $fh, 0, 0 );
+                if ( $virus ) {
+                    $found++;
+                    push @virus, {
+                        name      => $name,
+                        signature => $virus,
+                    };
+                    $c->log->warn( __PACKAGE__ . " VIRUS found. signature='$virus'" );
+                }
             }
-        }
         }
     }
     return wantarray ? @virus : $found;

--- a/lib/Catalyst/Plugin/ClamAV.pm
+++ b/lib/Catalyst/Plugin/ClamAV.pm
@@ -32,6 +32,7 @@ sub clamscan {
                     $found++;
                     push @virus, {
                         name      => $name,
+                        filename  => $upload->filename,
                         signature => $virus,
                     };
                     $c->log->warn( __PACKAGE__ . " VIRUS found. signature='$virus'" );
@@ -100,7 +101,11 @@ Catalyst::Plugin::ClamAV - ClamAV scanning Plugin for Catalyst
     my $found = $c->clamscan('field1', 'field2');
 
     my @found_virus = $c->clamscan('field1', 'field2');
-    # e.g. @found_virus == ( { name => 'field1', signature => 'VIRUSNAME' } );
+    # e.g. @found_virus == ( {
+    #          name      => 'field1',
+    #          filename  => 'filename',
+    #          signature => 'VIRUSNAME'
+    #      } );
 
 =head1 DESCRIPTION
 

--- a/lib/Catalyst/Plugin/ClamAV.pm
+++ b/lib/Catalyst/Plugin/ClamAV.pm
@@ -2,7 +2,8 @@ package Catalyst::Plugin::ClamAV;
 
 use strict;
 use warnings;
-use ClamAV::Client;
+use IO::Handle;
+use Net::ClamAV::Client;
 
 our $VERSION = '0.03';
 our $base    = 'clamav';
@@ -23,7 +24,8 @@ sub clamscan {
 
         my $fh = $upload->fh;
         if ($fh) {
-            my $virus = $scanner->scan_stream( $fh );
+            my $io = IO::Handle->new_from_fd($fh, 'r');
+            my $virus = $scanner->scanStreamFH( $io );
             seek( $fh, 0, 0 );
             if ( $virus ) {
                 $found++;
@@ -45,9 +47,19 @@ sub _init_clam {
     foreach my $n(qw( socket_name socket_host socket_port )){
         $opt{$n} = $c->config->{$base}->{$n} if defined $c->config->{$base}->{$n};
     }
+    my %new_opt;
+    if ( $opt{socket_name} ) {
+        $new_opt{url} = $opt{socket_name};
+    }
+    else {
+        my $host = $opt{socket_host} || 'localhost';
+        my $port = $opt{socket_port} || 3310;
+        $new_opt{url} = "$host:$port";
+    }
+
     my ( $scanner, $error );
     eval {
-        $scanner = ClamAV::Client->new( %opt );
+        $scanner = Net::ClamAV::Client->new( %new_opt );
         if ( !$scanner or !$scanner->ping ) {
             $error = 1;
         }
@@ -92,7 +104,7 @@ Catalyst::Plugin::ClamAV - ClamAV scanning Plugin for Catalyst
 
 This plugin add virus scan method (using ClamAV) for Catalyst.
 
-Using ClamAV::Client module.
+Using Net::ClamAV::Client module.
 
 =head1 CONFIGURATION
 
@@ -100,7 +112,7 @@ Using ClamAV::Client module.
   MyApp->config->{clamav}->{socket_host};    # TCP/IP host
   MyApp->config->{clamav}->{socket_port};    # TCP/IP port
 
-See ClamAV::Client POD.
+See Net::ClamAV::Client POD.
 
 =head1 METHODS
 
@@ -108,7 +120,7 @@ See ClamAV::Client POD.
 
 =item clamscan
 
-Scan uploaded file handles, using ClamAV::Client->scan_stream().
+Scan uploaded file handles, using Net::ClamAV::Client->scanStreamFH().
 Takes file upload field names as arguments.
 
 HTML:
@@ -135,7 +147,7 @@ To get found virus detail,
 
 =head1 SEE ALSO
 
-L<Catalyst> L<ClamAV::Client>
+L<Catalyst> L<Net::ClamAV::Client>
 
 =head1 AUTHOR
 

--- a/t/01-clamscan.t
+++ b/t/01-clamscan.t
@@ -9,7 +9,7 @@ use Catalyst::Test 'TestApp';
 use HTTP::Request::Common;
 use Data::Dumper;
 
-plan tests => 6;
+plan tests => 9;
 
 my $no_scan;
 if ( !$ENV{CLAMAV_SOCKET_NAME}
@@ -53,6 +53,33 @@ if ( !$ENV{CLAMAV_SOCKET_NAME}
                 Content => 'x' x 1024,
             ],
             'file2' => [
+                undef,
+                'bar.txt',
+                'Content-Type' => 'text/plain',
+                Content => 'y' x 1024,
+            ],
+        ]
+    );
+
+    ok( my $response = request($request), 'Request' );
+    ok( $response->is_success, 'Upload ok' );
+
+    my $content = $response->content;
+    ok( $content eq ( $no_scan ? '-1' : '0'), 'Scan ok' )
+}
+
+{
+    my $request = POST(
+        "http://localhost/upload",
+        'Content-Type' => 'multipart/form-data',
+        'Content'      => [
+            'file1' => [
+                undef,
+                'foo.txt',
+                'Content-Type' => 'text/plain',
+                Content => 'x' x 1024,
+            ],
+            'file1' => [
                 undef,
                 'bar.txt',
                 'Content-Type' => 'text/plain',


### PR DESCRIPTION
Catalyst::Plugin::ClamAV does not work after clamav-0.104.

This is beacuse Catalyst::Plugin::ClamAV depends on ClamAV::Client, and
ClamAV::Client uses clamd STREAM command deprecated on clamav-0.104.

So, I replace ClamAV::Client with Net::ClamAV::Client that uses new
INSTREAM command.